### PR TITLE
feat: add About dialog 

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-electron_mirror=https://npmmirror.com/mirrors/electron/
-electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "text-diff-view",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "text diff view electron app. Text-only.",
   "type": "module",
   "main": "./out/main/index.js",
@@ -51,7 +51,7 @@
     "@types/react-dom": "^18.3.0",
     "@vitejs/plugin-react": "^4.3.1",
     "autoprefixer": "^10.4.20",
-    "electron": "^40.1.0",
+    "electron": "^41.1.1",
     "electron-builder": "~26.5.0",
     "electron-vite": "^5.0.0",
     "eslint": "^8.57.0",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,12 +38,25 @@ export function initAutoUpdater(win: BrowserWindow): void {
   autoUpdater.autoDownload = true
   autoUpdater.autoInstallOnAppQuit = true
 
+  autoUpdater.on('checking-for-update', () => {
+    win.webContents.send('update-checking')
+  })
+
+  autoUpdater.on('update-available', (info) => {
+    win.webContents.send('update-available', info)
+  })
+
+  autoUpdater.on('update-not-available', () => {
+    win.webContents.send('update-not-available')
+  })
+
   autoUpdater.on('update-downloaded', (info) => {
     win.webContents.send('update-downloaded', info)
   })
 
   autoUpdater.on('error', (err) => {
     console.error('AutoUpdater error:', err)
+    win.webContents.send('update-error', err.message)
   })
 
   autoUpdater.checkForUpdates()
@@ -139,6 +152,20 @@ app.whenReady().then(() => {
 
   ipcMain.on('install-update', () => {
     autoUpdater.quitAndInstall()
+  })
+
+  // App version (synchronous)
+  ipcMain.on('get-app-version', (event) => {
+    event.returnValue = app.getVersion()
+  })
+
+  // Trigger update check from renderer (e.g. About dialog)
+  ipcMain.on('check-for-updates-now', () => {
+    if (!app.isPackaged) {
+      mainWindow.webContents.send('update-error', 'dev')
+      return
+    }
+    autoUpdater.checkForUpdates()
   })
 
   createWindow()

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,8 @@ declare global {
       GetThemeName: () => Promise<string | null>
       SetThemeName: (themeName: string) => Promise<void>
       installUpdate: () => void
+      getAppVersion: () => string
+      checkForUpdates: () => void
     }
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -11,6 +11,12 @@ const api = {
   },
   installUpdate: (): void => {
     ipcRenderer.send('install-update')
+  },
+  getAppVersion: (): string => {
+    return ipcRenderer.sendSync('get-app-version')
+  },
+  checkForUpdates: (): void => {
+    ipcRenderer.send('check-for-updates-now')
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -11,6 +11,7 @@ import {
 import { Button } from './components/ui/button'
 import { Separator } from './components/ui/separator'
 import { UnifiedDiffDialog } from './components/UnifiedDiffDialog'
+import { AboutDialog } from './components/AboutDialog'
 import { cn } from './lib/utils'
 
 type ThemeNameType = 'light' | 'dark'
@@ -47,6 +48,7 @@ function App(): JSX.Element {
     getThemeColorByThemeName('light')
   )
   const [unifiedDiffDialogOpen, setUnifiedDiffDialogOpen] = useState(false)
+  const [aboutOpen, setAboutOpen] = useState(false)
   const [updateInfo, setUpdateInfo] = useState<{ version: string } | null>(null)
 
   const options: monaco.editor.IDiffEditorOptions = {
@@ -177,14 +179,12 @@ function App(): JSX.Element {
 
         <div id="footer" className="flex justify-end space-x-3 items-center">
           <div>
-            <a
-              href="https://github.com"
-              className="text-xs text-muted-foreground"
-              target="_blank"
-              rel="noreferrer"
+            <button
+              className="text-xs text-muted-foreground hover:underline"
+              onClick={() => setAboutOpen(true)}
             >
               Text Diff View
-            </a>
+            </button>
           </div>
           <Separator orientation="vertical" className="h-full" />
           <div>
@@ -197,6 +197,12 @@ function App(): JSX.Element {
         open={unifiedDiffDialogOpen}
         onOpenChange={setUnifiedDiffDialogOpen}
         diffEditor={currentEditor.current}
+        themeName={selectedTheme.name}
+      />
+
+      <AboutDialog
+        open={aboutOpen}
+        onOpenChange={setAboutOpen}
         themeName={selectedTheme.name}
       />
 

--- a/src/renderer/src/components/AboutDialog.tsx
+++ b/src/renderer/src/components/AboutDialog.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog'
+import { Button } from './ui/button'
+import { cn } from '../lib/utils'
+import appIcon from '../../../../resources/icon.png'
+
+type UpdateStatus = 'checking' | 'up-to-date' | 'available' | 'downloaded' | 'error'
+
+interface AboutDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  themeName: 'light' | 'dark'
+}
+
+export function AboutDialog({ open, onOpenChange, themeName }: AboutDialogProps): JSX.Element {
+  const [version] = useState(() => window.api.getAppVersion())
+  const [updateStatus, setUpdateStatus] = useState<UpdateStatus>('checking')
+  const [latestVersion, setLatestVersion] = useState('')
+  const [isDevError, setIsDevError] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+
+    setUpdateStatus('checking')
+    setIsDevError(false)
+    window.api.checkForUpdates()
+
+    const onChecking = () => setUpdateStatus('checking')
+    const onNotAvailable = () => setUpdateStatus('up-to-date')
+    const onAvailable = (_e, info: { version: string }) => {
+      setUpdateStatus('available')
+      setLatestVersion(info.version)
+    }
+    const onDownloaded = (_e, info: { version: string }) => {
+      setUpdateStatus('downloaded')
+      setLatestVersion(info.version)
+    }
+    const onError = (_e, msg: string) => {
+      setIsDevError(msg === 'dev')
+      setUpdateStatus('error')
+    }
+
+    window.electron.ipcRenderer.on('update-checking', onChecking)
+    window.electron.ipcRenderer.on('update-not-available', onNotAvailable)
+    window.electron.ipcRenderer.on('update-available', onAvailable)
+    window.electron.ipcRenderer.on('update-downloaded', onDownloaded)
+    window.electron.ipcRenderer.on('update-error', onError)
+
+    return () => {
+      window.electron.ipcRenderer.removeListener('update-checking', onChecking)
+      window.electron.ipcRenderer.removeListener('update-not-available', onNotAvailable)
+      window.electron.ipcRenderer.removeListener('update-available', onAvailable)
+      window.electron.ipcRenderer.removeListener('update-downloaded', onDownloaded)
+      window.electron.ipcRenderer.removeListener('update-error', onError)
+    }
+  }, [open])
+
+  const renderUpdateStatus = () => {
+    switch (updateStatus) {
+      case 'checking':
+        return (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="4"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            <span>Checking for updates...</span>
+          </div>
+        )
+      case 'up-to-date':
+        return <p className="text-sm text-green-600">✓ Up to date</p>
+      case 'available':
+        return (
+          <p className="text-sm text-blue-500">↑ v{latestVersion} available (downloading...)</p>
+        )
+      case 'downloaded':
+        return (
+          <div className="flex items-center gap-2">
+            <p className="text-sm text-green-600">✓ v{latestVersion} ready to install</p>
+            <Button size="sm" onClick={() => window.api.installUpdate()}>
+              Restart and update
+            </Button>
+          </div>
+        )
+      case 'error':
+        return (
+          <p className="text-sm text-muted-foreground">
+            {isDevError ? '— Not available in development' : '✗ Failed to check for updates'}
+          </p>
+        )
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn('max-w-sm bg-background text-foreground', themeName === 'dark' && 'dark')}
+        aria-describedby={undefined}
+      >
+        <DialogHeader>
+          <DialogTitle>About</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col items-center gap-4 py-4">
+          <img src={appIcon} className="w-20 h-20 rounded-2xl" alt="Text Diff View" />
+          <div className="text-center">
+            <h2 className="text-xl font-semibold">Text Diff View</h2>
+            <p className="text-sm text-muted-foreground mt-1">Version {version}</p>
+          </div>
+          <div>{renderUpdateStatus()}</div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,10 +2548,10 @@ electron-vite@^5.0.0:
     magic-string "^0.30.19"
     picocolors "^1.1.1"
 
-electron@^40.1.0:
-  version "40.8.5"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-40.8.5.tgz#a7e459a2eee35bd02c32da87170c920383656c4d"
-  integrity sha512-pgTY/VPQKaiU4sTjfU96iyxCXrFm4htVPCMRT4b7q9ijNTRgtLmLvcmzp2G4e7xDrq9p7OLHSmu1rBKFf6Y1/A==
+electron@^41.1.1:
+  version "41.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-41.1.1.tgz#ec2016ad886b4377a4b643fa34fe9cbcd8d7f015"
+  integrity sha512-8bgvDhBjli+3Z2YCKgzzoBPh6391pr7Xv2h/tTJG4ETgvPvUxZomObbZLs31mUzYb6VrlcDDd9cyWyNKtPm3tA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^24.9.0"


### PR DESCRIPTION
- Add AboutDialog component with app icon, version, and auto-update status
- Trigger dialog from footer "Text Diff View" button
- Add get-app-version and check-for-updates-now IPC handlers
- Expose getAppVersion() and checkForUpdates() via preload
- Bump version to 1.8.0, update Electron to ^41.1.1